### PR TITLE
Use rustfmt's defaults.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-indent_style="Block"
-imports_indent="Block"
-use_try_shorthand=true
-use_field_init_shorthand=true
-merge_imports=true

--- a/lang_tests/run.rs
+++ b/lang_tests/run.rs
@@ -15,9 +15,7 @@ lazy_static! {
 fn main() {
     LangTester::new()
         .test_dir("lang_tests")
-        .test_file_filter(|p| {
-            p.extension().unwrap().to_str().unwrap() == "bf"
-        })
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "bf")
         .test_extract(|s| {
             EXPECTED
                 .captures(s)


### PR DESCRIPTION
Clinging on to custom settings probably doesn't make sense any more.