### PR TITLE
Allow building with --release.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# FIXME for software tracing we could optimise.
+[profile.release]
+opt-level = 0
+
+[profile.bench]
+opt-level = 0


### PR DESCRIPTION
Hardware tracing requires that LLVM does not optimise.